### PR TITLE
Update themes/hacs.yaml after docs changed

### DIFF
--- a/themes/hacs.yaml
+++ b/themes/hacs.yaml
@@ -1,4 +1,4 @@
 # Sample theme repository for HACS.
 # https://github.com/ludeeus/theme-hacs
-
-primary-color: '#f30cdf'
+hacs:
+  primary-color: '#f30cdf'


### PR DESCRIPTION
After changing the docs https://github.com/custom-components/hacs/pull/328, also the template should be updated.
With this config, users could also use their old themes.yaml file and copy it to the included themes directory.